### PR TITLE
Badge for push notifications can be zero

### DIFF
--- a/src/Apple/ApnPush/Messages/ApsData.php
+++ b/src/Apple/ApnPush/Messages/ApsData.php
@@ -171,9 +171,9 @@ class ApsData implements ApsDataInterface
             return $this;
         }
 
-        if (0 >= (int) $badge) {
+        if (0 > (int) $badge) {
             throw new \InvalidArgumentException(sprintf(
-                'Badge key must be large than zero (%s)!',
+                'Badge key cannot be less than zero (%s)!',
                 $badge
             ));
         }
@@ -204,7 +204,7 @@ class ApsData implements ApsDataInterface
             $apsData['sound'] = $this->sound;
         }
 
-        if ($this->badge) {
+        if ($this->badge !== null) {
             $apsData['badge'] = $this->badge;
         }
 


### PR DESCRIPTION
Found myself wanting to send a push notification with the badge set to 0 to reset the badge count for an app, but wasn't allowed by the AppleApnPush. Apple accepts 0 and removes the the badge correctly from the app.

Great library, by the way! Thanks.
