### PR TITLE
Ability to disable error checking when sending notifications

### DIFF
--- a/src/Apple/ApnPush/Notification/Notification.php
+++ b/src/Apple/ApnPush/Notification/Notification.php
@@ -39,6 +39,11 @@ class Notification implements NotificationInterface
     protected $logger;
 
     /**
+     * @var bool
+     */
+    protected $checkForErrors = true;
+
+    /**
      * Construct
      */
     public function __construct(PayloadFactoryInterface $payloadFactory = null, ConnectionInterface $connection = null)
@@ -116,7 +121,7 @@ class Notification implements NotificationInterface
 
         $response = (mb_strlen($payload) === $this->connection->write($payload, mb_strlen($payload)));
 
-        if ($this->connection->isReadyRead()) {
+        if ($this->checkForErrors && $this->connection->isReadyRead()) {
             $responseApple = $this->connection->read(6);
             $error = SendException::parseFromAppleResponse($responseApple, $message);
 
@@ -156,5 +161,13 @@ class Notification implements NotificationInterface
     public function getLogger()
     {
         return $this->logger;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setCheckForErrors($check)
+    {
+        return $this->checkForErrors = $check;
     }
 }

--- a/src/Apple/ApnPush/Notification/NotificationInterface.php
+++ b/src/Apple/ApnPush/Notification/NotificationInterface.php
@@ -69,4 +69,11 @@ interface NotificationInterface
      * @return LoggerInterface
      */
     public function getLogger();
+
+    /**
+     * Set whether or not to check for errors
+     *
+     * @param bool $check
+     */
+    public function setCheckForErrors($check);
 }


### PR DESCRIPTION
I noticed when sending thousands of notifications at a time that the isReadyRead() caused a huge slowdown, as its default is to wait 1 second after every notification. I know the amount of time it waits can be changed, but sometimes I'd rather disable the error checks completely.

The PHP stream_select() documentation states the following:

```
Using a timeout value of 0 allows you to instantaneously poll the status
of the streams, however, it is NOT a good idea to use a 0 timeout value
in a loop as it will cause your script to consume too much CPU time.

It is much better to specify a timeout value of a few seconds, although
if you need to be checking and running other code concurrently, using
a timeout value of at least 200000 microseconds will help reduce the
CPU usage of your script. 
```

I could change the wait to 0.2 seconds, per the recommendation, but sometimes I simply don't care if a message here or there fails and I'd rather have the speed that comes without checking for errors.
