### PR TITLE
Increase maximum payload size to 2KB per increase in iOS 8

### DIFF
--- a/src/Apple/ApnPush/Notification/PayloadFactory.php
+++ b/src/Apple/ApnPush/Notification/PayloadFactory.php
@@ -41,7 +41,7 @@ class PayloadFactory implements PayloadFactoryInterface
         $payloadSize = strlen($jsonData);
 
         // Check payload size
-        if ($payloadSize > 255) {
+        if ($payloadSize > 2048) {
             throw new SendException(SendException::ERROR_INVALID_PAYLOAD_SIZE, 1, $message->getIdentifier(), $message);
         }
 


### PR DESCRIPTION
Per APNS docs, the maximum payload size has been increased to 2 KB in iOS 8. I increased the check in `PayloadFactory` to accept this larger size.

https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html#//apple_ref/doc/uid/TP40008194-CH100-SW1