### PR TITLE
Added support for iOS 8 Action categories

### DIFF
--- a/src/Apple/ApnPush/Notification/ApsData.php
+++ b/src/Apple/ApnPush/Notification/ApsData.php
@@ -32,6 +32,11 @@ class ApsData implements ApsDataInterface, \Serializable
     protected $sound;
 
     /**
+     * @var string
+     */
+    protected $category;
+
+    /**
      * @var integer
      */
     protected $badge;
@@ -92,6 +97,43 @@ class ApsData implements ApsDataInterface, \Serializable
     public function getBody()
     {
         return $this->body;
+    }
+
+    /**
+     * Set category for iOS 8 notification actions
+     *
+     * @param string $category
+     *
+     * @return ApsData
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function setCategory($category)
+    {
+        if (is_object($category)) {
+            $category = (string) $category;
+        }
+
+        if ($category !== null && !is_scalar($category)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Category must be string, "%s" given.',
+                gettype($category)
+            ));
+        }
+
+        $this->category = $category;
+
+        return $this;
+    }
+
+    /**
+     * Get category
+     *
+     * @return string
+     */
+    public function getCategory()
+    {
+        return $this->category;
     }
 
     /**
@@ -280,6 +322,10 @@ class ApsData implements ApsDataInterface, \Serializable
             $apsData['badge'] = $this->badge;
         }
 
+        if (null !== $this->category) {
+            $apsData['category'] = $this->category;
+        }
+
         if (true === $this->contentAvailable) {
             $apsData['content-available'] = 1;
         }
@@ -298,7 +344,8 @@ class ApsData implements ApsDataInterface, \Serializable
             'body' => $this->body,
             'body_custom' => $this->bodyCustom,
             'sound' => $this->sound,
-            'badge' => $this->badge
+            'badge' => $this->badge,
+            'category' => $this->category
         );
 
         if (true === $this->contentAvailable) {
@@ -321,7 +368,8 @@ class ApsData implements ApsDataInterface, \Serializable
             ->setBody($data['body'])
             ->setBodyCustom($data['body_custom'])
             ->setSound($data['sound'])
-            ->setBadge($data['badge']);
+            ->setBadge($data['badge'])
+            ->setCategory($data['category']);
 
         if (isset($data['content-available'])) {
             $this->setContentAvailable($data['content-available']);

--- a/src/Apple/ApnPush/Notification/ApsDataInterface.php
+++ b/src/Apple/ApnPush/Notification/ApsDataInterface.php
@@ -31,6 +31,20 @@ interface ApsDataInterface extends PayloadDataInterface
     public function getBody();
 
     /**
+     * Set category for iOS 8 notification actions
+     *
+     * @param string $category
+     */
+    public function setCategory($category);
+
+    /**
+     * Get category
+     *
+     * @return mixed
+     */
+    public function getCategory();
+
+    /**
      * Set body localize
      *
      * @param string $localizeKey

--- a/src/Apple/ApnPush/Notification/Message.php
+++ b/src/Apple/ApnPush/Notification/Message.php
@@ -223,6 +223,30 @@ class Message implements MessageInterface, \Serializable
     }
 
     /**
+     * Set category
+     *
+     * @param string $category
+     *
+     * @return Message
+     */
+    public function setCategory($category)
+    {
+        $this->apsData->setCategory($category);
+
+        return $this;
+    }
+
+    /**
+     * Get category
+     *
+     * @return string
+     */
+    public function getCategory()
+    {
+        return $this->apsData->getCategory();
+    }
+
+    /**
      * Set body localize
      *
      * @param string $localizeKey

--- a/src/Apple/ApnPush/Notification/MessageInterface.php
+++ b/src/Apple/ApnPush/Notification/MessageInterface.php
@@ -67,6 +67,20 @@ interface MessageInterface extends PayloadDataInterface
     public function getBody();
 
     /**
+     * Set category
+     *
+     * @param string $category
+     */
+    public function setCategory($category);
+
+    /**
+     * Get category
+     *
+     * @return string
+     */
+    public function getCategory();
+
+    /**
      * Set APS data
      *
      * @param ApsDataInterface $apsData


### PR DESCRIPTION
As described in the [docs](https://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/IPhoneOSClientImp.html#//apple_ref/doc/uid/TP40008194-CH103-SW36), the 'aps' node accepts a child object 'category', that should contain the locally registered category ID.