### PR TITLE
Added guard for using custom data in constructor of payload.

### DIFF
--- a/src/Model/Payload.php
+++ b/src/Model/Payload.php
@@ -92,7 +92,7 @@ class Payload
      */
     public function withCustomData(string $name, $value): Payload
     {
-        $this->validateCustomDataValue($value);
+        $this->guardValue($value);
 
         $cloned = clone $this;
 
@@ -123,12 +123,10 @@ class Payload
                 $this->guardValue($value);
                 $this->guardKey($key);
             }
-            $this->validateCustomDataValue($value);
-            $this->validateCustomDataKey($key);
         }
     }
 
-    private function validateCustomDataValue($value)
+    private function guardValue($value)
     {
         if ($value && !is_array($value) && !is_scalar($value) && !$value instanceof \JsonSerializable) {
             throw new \InvalidArgumentException(sprintf(
@@ -138,7 +136,7 @@ class Payload
         }
     }
 
-    private function validateCustomDataKey($key)
+    private function guardKey($key)
     {
         if (! is_string($key)) {
             throw new \InvalidArgumentException(sprintf(

--- a/src/Model/Payload.php
+++ b/src/Model/Payload.php
@@ -92,7 +92,7 @@ class Payload
      */
     public function withCustomData(string $name, $value): Payload
     {
-        $this->guardValue($value);
+        $this->validateCustomDataValue($value);
 
         $cloned = clone $this;
 
@@ -123,10 +123,12 @@ class Payload
                 $this->guardValue($value);
                 $this->guardKey($key);
             }
+            $this->validateCustomDataValue($value);
+            $this->validateCustomDataKey($key);
         }
     }
 
-    private function guardValue($value)
+    private function validateCustomDataValue($value)
     {
         if ($value && !is_array($value) && !is_scalar($value) && !$value instanceof \JsonSerializable) {
             throw new \InvalidArgumentException(sprintf(
@@ -136,7 +138,7 @@ class Payload
         }
     }
 
-    private function guardKey($key)
+    private function validateCustomDataKey($key)
     {
         if (! is_string($key)) {
             throw new \InvalidArgumentException(sprintf(

--- a/src/Model/Payload.php
+++ b/src/Model/Payload.php
@@ -36,6 +36,8 @@ class Payload
      */
     public function __construct(Aps $apsData, array $customData = [])
     {
+        $this->guardCustomData($customData);
+
         $this->aps = $apsData;
         $this->customData = $customData;
     }
@@ -90,12 +92,7 @@ class Payload
      */
     public function withCustomData(string $name, $value): Payload
     {
-        if ($value && !is_array($value) && !is_scalar($value) && !$value instanceof \JsonSerializable) {
-            throw new \InvalidArgumentException(sprintf(
-                'The custom data value should be a scalar or \JsonSerializable instance, but "%s" given.',
-                is_object($value) ? get_class($value) : gettype($value)
-            ));
-        }
+        $this->guardValue($value);
 
         $cloned = clone $this;
 
@@ -112,5 +109,40 @@ class Payload
     public function getCustomData(): array
     {
         return $this->customData;
+    }
+
+    /**
+     * Guard the custom data upon instantiation.
+     *
+     * @param array $data
+     */
+    private function guardCustomData(array $data)
+    {
+        if (false === empty($data)) {
+            foreach ($data as $key => $value) {
+                $this->guardValue($value);
+                $this->guardKey($key);
+            }
+        }
+    }
+
+    private function guardValue($value)
+    {
+        if ($value && !is_array($value) && !is_scalar($value) && !$value instanceof \JsonSerializable) {
+            throw new \InvalidArgumentException(sprintf(
+                'The custom data value should be a scalar or \JsonSerializable instance, but "%s" given.',
+                is_object($value) ? get_class($value) : gettype($value)
+            ));
+        }
+    }
+
+    private function guardKey($key)
+    {
+        if (! is_string($key)) {
+            throw new \InvalidArgumentException(sprintf(
+                'The custom data key should be a string, but "%s" given.',
+                gettype($key)
+            ));
+        }
     }
 }

--- a/src/Model/Payload.php
+++ b/src/Model/Payload.php
@@ -92,7 +92,7 @@ class Payload
      */
     public function withCustomData(string $name, $value): Payload
     {
-        $this->guardValue($value);
+        $this->validateCustomDataValue($value);
 
         $cloned = clone $this;
 
@@ -120,13 +120,13 @@ class Payload
     {
         if (false === empty($data)) {
             foreach ($data as $key => $value) {
-                $this->guardValue($value);
-                $this->guardKey($key);
+                $this->validateCustomDataValue($value);
+                $this->validateCustomDataKey($key);
             }
         }
     }
 
-    private function guardValue($value)
+    private function validateCustomDataValue($value)
     {
         if ($value && !is_array($value) && !is_scalar($value) && !$value instanceof \JsonSerializable) {
             throw new \InvalidArgumentException(sprintf(
@@ -136,7 +136,7 @@ class Payload
         }
     }
 
-    private function guardKey($key)
+    private function validateCustomDataKey($key)
     {
         if (! is_string($key)) {
             throw new \InvalidArgumentException(sprintf(

--- a/src/Model/Payload.php
+++ b/src/Model/Payload.php
@@ -118,11 +118,9 @@ class Payload
      */
     private function guardCustomData(array $data)
     {
-        if (false === empty($data)) {
-            foreach ($data as $key => $value) {
-                $this->validateCustomDataValue($value);
-                $this->validateCustomDataKey($key);
-            }
+        foreach ($data as $key => $value) {
+            $this->validateCustomDataValue($value);
+            $this->validateCustomDataKey($key);
         }
     }
 

--- a/tests/Model/PayloadTest.php
+++ b/tests/Model/PayloadTest.php
@@ -69,6 +69,28 @@ class PayloadTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The custom data value should be a scalar or \JsonSerializable instance, but "stdClass" given.
      */
+    public function shouldThrowExceptionIfUsingWrongCustomDataValueOnConstruction()
+    {
+        new Payload(new Aps(new Alert()), ['some-key' => new \stdClass()]);
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The custom data key should be a string, but "integer" given.
+     */
+    public function shouldThrowExceptionIfUsingWrongCustomDataKeyOnConstruction()
+    {
+        new Payload(new Aps(new Alert()), [0 => 'test']);
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The custom data value should be a scalar or \JsonSerializable instance, but "stdClass" given.
+     */
     public function shouldThrowExceptionIfTrySetInvalidCustomData()
     {
         $payload = new Payload(new Aps(new Alert()));


### PR DESCRIPTION
When using `withCustomData()` we are throwing an exception if the value is not a of scalar type. 

But not when the object custructor is used for setting the custom payload. 
This should fix that. 