### PR TITLE
add support for mutable-content attribute in Aps

### DIFF
--- a/src/Encoder/PayloadEncoder.php
+++ b/src/Encoder/PayloadEncoder.php
@@ -65,6 +65,10 @@ class PayloadEncoder implements PayloadEncoderInterface
             $data['content-available'] = 1;
         }
 
+        if ($aps->isMutableContent()) {
+            $data['mutable-content'] = 1;
+        }
+
         if ($aps->getThreadId()) {
             $data['thread-id'] = $aps->getThreadId();
         }

--- a/src/Model/Aps.php
+++ b/src/Model/Aps.php
@@ -39,6 +39,11 @@ class Aps
     private $contentAvailable = false;
 
     /**
+     * @var bool
+    */
+    private $mutableContent = false;
+
+    /**
      * @var string
      */
     private $category = '';
@@ -186,6 +191,32 @@ class Aps
     public function isContentAvailable(): bool
     {
         return $this->contentAvailable;
+    }
+
+    /**
+     * Set mutable content option
+     *
+     * @param bool $mutableContent
+     *
+     * @return Aps
+     */
+    public function withMutableContent(bool $mutableContent): Aps
+    {
+        $cloned = clone $this;
+
+        $cloned->mutableContent = $mutableContent;
+
+        return $cloned;
+    }
+
+    /**
+     * Get mutable content option
+     *
+     * @return bool
+     */
+    public function isMutableContent(): bool
+    {
+        return $this->mutableContent;
     }
 
     /**

--- a/tests/Encoder/PayloadEncoderTest.php
+++ b/tests/Encoder/PayloadEncoderTest.php
@@ -176,6 +176,20 @@ class PayloadEncoderTest extends TestCase
     /**
      * @test
      */
+    public function shouldSuccessEncodeWithMutableContent()
+    {
+        $aps = new Aps(new Alert());
+        $aps = $aps->withMutableContent(true);
+
+        $payload = new Payload($aps);
+        $encoded = $this->encoder->encode($payload);
+
+        self::assertEquals('{"aps":{"alert":{"body":""},"mutable-content":1}}', $encoded);
+    }
+
+    /**
+     * @test
+     */
     public function shouldSuccessEncodeWithThreadId()
     {
         $aps = new Aps(new Alert());

--- a/tests/Model/ApsTest.php
+++ b/tests/Model/ApsTest.php
@@ -93,6 +93,18 @@ class ApsTest extends TestCase
     /**
      * @test
      */
+    public function shouldSuccessChangeMutableContent()
+    {
+        $aps = new Aps(new Alert());
+        $apsWithChangedMutableContent = $aps->withMutableContent(true);
+
+        self::assertTrue($apsWithChangedMutableContent->isMutableContent());
+        self::assertNotEquals(spl_object_hash($aps), spl_object_hash($apsWithChangedMutableContent));
+    }
+
+    /**
+     * @test
+     */
     public function shouldSuccessChangeThread()
     {
         $aps = new Aps(new Alert());


### PR DESCRIPTION
Supporting mutable-content attribute, which lets you customize the content of a remote notification before it is delivered to the user.
https://developer.apple.com/documentation/usernotifications/unnotificationserviceextension