### PR TITLE
[WIP] Adding a concurrent curl sender

### DIFF
--- a/src/Protocol/Http/Response.php
+++ b/src/Protocol/Http/Response.php
@@ -19,6 +19,11 @@ namespace Apple\ApnPush\Protocol\Http;
 class Response
 {
     /**
+     * @var float
+     */
+    private $time;
+
+    /**
      * @var int
      */
     private $statusCode;
@@ -33,11 +38,13 @@ class Response
      *
      * @param int    $statusCode
      * @param string $content
+     * @param float  $requestTime
      */
-    public function __construct(int $statusCode, string $content)
+    public function __construct(int $statusCode, string $content, float $requestTime)
     {
         $this->statusCode = $statusCode;
         $this->content = $content;
+        $this->time = $requestTime;
     }
 
     /**
@@ -48,6 +55,16 @@ class Response
     public function getStatusCode(): int
     {
         return $this->statusCode;
+    }
+
+    /**
+     * Get request time
+     *
+     * @return float
+     */
+    public function getTime(): float
+    {
+        return $this->time;
     }
 
     /**

--- a/src/Protocol/Http/Sender/CurlMultiSender.php
+++ b/src/Protocol/Http/Sender/CurlMultiSender.php
@@ -60,9 +60,9 @@ class CurlMultiSender implements HttpSenderInterface
      *
      * @param int $maxRequests
      *
-     * @return CurlMultiSender
+     * @return HttpSenderInterface
      */
-    public function maxRequests(int $maxRequests)
+    public function maxRequests(int $maxRequests): HttpSenderInterface
     {
         $this->maxConcurrentRequests = $maxRequests;
 
@@ -74,9 +74,9 @@ class CurlMultiSender implements HttpSenderInterface
      *
      * @param int $timeout
      *
-     * @return CurlMultiSender
+     * @return HttpSenderInterface
      */
-    public function timeout(int $timeout)
+    public function timeout(int $timeout): HttpSenderInterface
     {
         $this->timeout = $timeout;
 

--- a/src/Protocol/Http/Sender/CurlMultiSender.php
+++ b/src/Protocol/Http/Sender/CurlMultiSender.php
@@ -173,9 +173,9 @@ class CurlMultiSender implements HttpSenderInterface
      *
      * @param array $request
      *
-     * @return array|mixed
+     * @return array
      */
-    private function buildOptions(array $request)
+    private function buildOptions(array $request): array
     {
         $url = $request['url'];
         $postData = $request['post_data'];
@@ -208,8 +208,10 @@ class CurlMultiSender implements HttpSenderInterface
      * @param $requestNumber
      * @param $multiHandler
      * @param $requestsMap
+     *
+     * @return void
      */
-    private function initRequest($requestNumber, $multiHandler, &$requestsMap)
+    private function initRequest($requestNumber, $multiHandler, &$requestsMap): void
     {
         $curlHandler = curl_init();
 
@@ -241,7 +243,7 @@ class CurlMultiSender implements HttpSenderInterface
      *
      * @return void
      */
-    private function processSingleRequest($completed, $multiHandle, array &$requestsMap)
+    private function processSingleRequest($completed, $multiHandle, array &$requestsMap): void
     {
         $curlHandle = $completed['handle'];
         $curlHandleHash = (int)$curlHandle;
@@ -280,8 +282,10 @@ class CurlMultiSender implements HttpSenderInterface
      * Add a timer on the request.
      *
      * @param array $request
+     *
+     * @return void
      */
-    private function addTimer(array &$request)
+    private function addTimer(array &$request): void
     {
         $request['timer'] = microtime(true); //start time
         $request['time'] = 0; //default if not overridden by time later
@@ -294,7 +298,7 @@ class CurlMultiSender implements HttpSenderInterface
      *
      * @return float
      */
-    private function stopTimer(array &$request)
+    private function stopTimer(array &$request): float
     {
         $elapsed = $request['timer'] - microtime(true);
         $request['time'] = $elapsed;
@@ -367,9 +371,11 @@ class CurlMultiSender implements HttpSenderInterface
     /**
      * Save cpu cycles
      * prevent continuous checking
+     *
+     * @return void
      */
-    private function saveCycles()
+    private function saveCycles(): void
     {
-        return usleep(15);
+        usleep(15);
     }
 }

--- a/src/Protocol/Http/Sender/CurlMultiSender.php
+++ b/src/Protocol/Http/Sender/CurlMultiSender.php
@@ -1,0 +1,375 @@
+<?php
+
+namespace Apple\ApnPush\Protocol\Http\Sender;
+
+use Apple\ApnPush\Protocol\Http\Request;
+use Apple\ApnPush\Protocol\Http\Response;
+use RuntimeException;
+
+/**
+ * Class CurlMultiSender
+ *
+ * @package Apple\ApnPush\Protocol\Http\Sender
+ */
+class CurlMultiSender implements HttpSenderInterface
+{
+    /**
+     * The curl version used
+     *
+     * @var
+     */
+    private $curlVersion;
+
+    /**
+     * Max number of simultaneous connections allowed
+     *
+     * @var int
+     */
+    private $maxConcurrentRequests = 10;
+
+    /**
+     * Global timeout all requests must be completed by this time
+     *
+     * @var int
+     */
+    private $timeout = 5000;
+
+    /**
+     * The request queue
+     *
+     * @var array
+     */
+    private $requests = [];
+
+    /**
+     * CurlMultiSender constructor.
+     *
+     * @param int $maxRequests
+     * @param int $timeout
+     */
+    public function __construct($maxRequests = 10, $timeout = 5000)
+    {
+        $this->maxRequests($maxRequests);
+        $this->timeout($timeout);
+
+        $this->curlVersion = curl_version()['version'];
+    }
+
+    /**
+     * Set max concurrent requests.
+     *
+     * @param int $maxRequests
+     *
+     * @return CurlMultiSender
+     */
+    public function maxRequests(int $maxRequests)
+    {
+        $this->maxConcurrentRequests = $maxRequests;
+
+        return $this;
+    }
+
+    /**
+     * Set the global requests timeout.
+     *
+     * @param int $timeout
+     *
+     * @return CurlMultiSender
+     */
+    public function timeout(int $timeout)
+    {
+        $this->timeout = $timeout;
+
+        return $this;
+    }
+
+    /**
+     * Add a request to the request queue
+     *
+     * @param Request  $request
+     * @param callable $callback
+     *
+     * @return void
+     */
+    public function addRequest(Request $request, callable $callback): void
+    {
+        $inlineHeaders = [];
+        $options = [];
+
+        foreach ($request->getHeaders() as $name => $value) {
+            $inlineHeaders[] = sprintf('%s: %s', $name, $value);
+        }
+
+        if ($request->getCertificate()) {
+            $options[CURLOPT_SSLCERT] = $request->getCertificate();
+            $options[CURLOPT_SSLCERTPASSWD] = $request->getCertificatePassPhrase();
+        }
+
+        $this->requests[] = [
+            'url'       => $request->getUrl(),
+            'post_data' => $request->getContent(),
+            'callback'  => $callback,
+            'options'   => $options,
+            'headers'   => $inlineHeaders,
+        ];
+    }
+
+    /**
+     * Reset request queue
+     *
+     * @param $multiCurlHandle
+     */
+    private function reset($multiCurlHandle)
+    {
+        $this->requests = [];
+        curl_multi_close($multiCurlHandle);
+    }
+
+    /**
+     * Execute the request queue
+     *
+     */
+    public function send(): void
+    {
+        $active = null;
+        $requestsMap = [];
+        $multiHandle = curl_multi_init();
+        $requestsRunning = 0;
+
+        $requestsToRun = $this->requestsToRun();
+        for ($i = 0; $i < $requestsToRun; $i++) {
+            $this->initRequest($i, $multiHandle, $requestsMap);
+            $requestsRunning++;
+        }
+
+        do {
+            do {
+                $handlerStatus = curl_multi_exec($multiHandle, $active);
+            } while ($handlerStatus === CURLM_CALL_MULTI_PERFORM);
+
+            if ($handlerStatus !== CURLM_OK) {
+                break;
+            }
+
+            while ($completed = curl_multi_info_read($multiHandle)) {
+                $this->processSingleRequest($completed, $multiHandle, $requestsMap);
+                $requestsRunning--;
+
+                while ($this->shouldStartNewRequest($requestsRunning, $i)) {
+                    $this->initRequest($i, $multiHandle, $requestsMap);
+                    $requestsRunning++;
+                    $i++;
+                }
+            }
+
+            $this->saveCycles();
+        } while ($active || count($requestsMap));
+
+        $this->reset($multiHandle);
+    }
+
+    /**
+     * Build individual cURL options for a request
+     *
+     * @param array $request
+     *
+     * @return array|mixed
+     */
+    private function buildOptions(array $request)
+    {
+        $url = $request['url'];
+        $postData = $request['post_data'];
+
+        $options = $request['options'];
+
+        $options[CURLOPT_RETURNTRANSFER] = true;
+        $options[CURLOPT_NOSIGNAL] = 1;
+        $options[CURLOPT_HTTPHEADER] = $request['headers'];
+        $options[CURLOPT_URL] = $url;
+        $options[CURLOPT_POST] = 1;
+        $options[CURLOPT_POSTFIELDS] = $postData;
+        $options[CURLOPT_HTTP_VERSION] = 3;
+
+        if (version_compare($this->curlVersion, '7.16.2') >= 0) {
+            $options[CURLOPT_CONNECTTIMEOUT_MS] = $this->timeout;
+            $options[CURLOPT_TIMEOUT_MS] = $this->timeout;
+        } else {
+            $options[CURLOPT_CONNECTTIMEOUT] = round($this->timeout / 1000);
+            $options[CURLOPT_TIMEOUT] = round($this->timeout / 1000);
+        }
+
+        return $options;
+    }
+
+
+    /**
+     * Initialize Curl request
+     *
+     * @param $requestNumber
+     * @param $multiHandler
+     * @param $requestsMap
+     */
+    private function initRequest($requestNumber, $multiHandler, &$requestsMap)
+    {
+        $curlHandler = curl_init();
+
+        $request =& $this->requests[$requestNumber];
+
+        $options = $this->buildOptions($request);
+        $request['options_set'] = $options; //merged options
+
+        if (false === curl_setopt_array($curlHandler, $options)) {
+            throw new RuntimeException('Invalid options passed to curl');
+        }
+
+        $this->addTimer($request);
+
+        curl_multi_add_handle($multiHandler, $curlHandler);
+
+        //add curl handle of a new request to the request map
+        $curlHandleHash = (int)$curlHandler;
+        $requestsMap[$curlHandleHash] = $requestNumber;
+    }
+
+
+    /**
+     * Process the response from a request.
+     *
+     * @param       $completed
+     * @param       $multiHandle
+     * @param array $requestsMap
+     *
+     * @return void
+     */
+    private function processSingleRequest($completed, $multiHandle, array &$requestsMap)
+    {
+        $curlHandle = $completed['handle'];
+        $curlHandleHash = (int)$curlHandle;
+        $request =& $this->requests[$requestsMap[$curlHandleHash]];
+
+        $requestInfo = curl_getinfo($curlHandle);
+        $requestInfo['time'] = $time = $this->stopTimer($request);
+
+        if (true === $this->serverRespondedWithError($curlHandle, $requestInfo)) {
+            $response = '';
+        } else {
+            $response = curl_multi_getcontent($curlHandle);
+        }
+
+        // remove completed request and its curl handle
+        unset($requestsMap[$curlHandleHash]);
+        curl_multi_remove_handle($multiHandle, $curlHandle);
+
+        // get request info
+        $callback = $request['callback'];
+
+        $callback(
+            new Response(
+                (int) $requestInfo['http_code'],
+                (string) $response,
+                (float) $time
+            )
+        );
+
+        unset($requestInfo);
+        unset($request);
+        unset($time);
+    }
+
+    /**
+     * Add a timer on the request.
+     *
+     * @param array $request
+     */
+    private function addTimer(array &$request)
+    {
+        $request['timer'] = microtime(true); //start time
+        $request['time'] = 0; //default if not overridden by time later
+    }
+
+    /**
+     * Stop request timer.
+     *
+     * @param array $request
+     *
+     * @return float
+     */
+    private function stopTimer(array &$request)
+    {
+        $elapsed = $request['timer'] - microtime(true);
+        $request['time'] = $elapsed;
+        unset($request['timer']);
+
+        return $elapsed;
+    }
+
+    /**
+     * Determine how many requests should run.
+     *
+     * @return integer
+     */
+    private function requestsToRun(): int
+    {
+        return (int) min($this->maxConcurrentRequests, count($this->requests));
+    }
+
+    /**
+     * Determine if the request failed
+     *
+     * @param $curlHandle
+     * @param $requestInfo
+     *
+     * @return bool
+     */
+    private function serverRespondedWithError($curlHandle, array $requestInfo): bool
+    {
+        return curl_errno($curlHandle) !== 0 || (int) $requestInfo['http_code'] !== 200;
+    }
+
+    /**
+     * Determine if the running requests is
+     * still under the concurrent requests limit.
+     *
+     * @param $requestsRunning
+     *
+     * @return bool
+     */
+    private function isUnderRequestLimit(int $requestsRunning): bool
+    {
+        return $requestsRunning < $this->maxConcurrentRequests;
+    }
+
+    /**
+     * Determine if we have any request left to run
+     *
+     * @param $iterator
+     *
+     * @return bool
+     */
+    private function hasRequestsLeft(int $iterator): bool
+    {
+        return $iterator < count($this->requests) && isset($this->requests[$iterator]);
+    }
+
+    /**
+     * Determine if we should start a new request
+     *
+     * @param $requestsRunning
+     * @param $iterator
+     *
+     * @return bool
+     */
+    private function shouldStartNewRequest(int $requestsRunning, int $iterator): bool
+    {
+        return $this->isUnderRequestLimit($requestsRunning) && $this->hasRequestsLeft($iterator);
+    }
+
+    /**
+     * Save cpu cycles
+     * prevent continuous checking
+     */
+    private function saveCycles()
+    {
+        return usleep(15);
+    }
+}

--- a/src/Protocol/Http/Sender/HttpSenderInterface.php
+++ b/src/Protocol/Http/Sender/HttpSenderInterface.php
@@ -14,7 +14,6 @@ declare(strict_types = 1);
 namespace Apple\ApnPush\Protocol\Http\Sender;
 
 use Apple\ApnPush\Protocol\Http\Request;
-use Apple\ApnPush\Protocol\Http\Response;
 use Apple\ApnPush\Protocol\Http\Sender\Exception\HttpSenderException;
 
 /**
@@ -25,16 +24,17 @@ interface HttpSenderInterface
     /**
      * Send HTTP request
      *
-     * @param Request $request
-     *
-     * @return Response
+     * @return void
      *
      * @throws HttpSenderException
      */
-    public function send(Request $request): Response;
+    public function send(): void;
 
     /**
-     * Close connection
+     * @param Request  $request
+     *
+     * @param callable $callback
+     *
      */
-    public function close(): void;
+    public function addRequest(Request $request, callable $callback);
 }

--- a/src/Protocol/Http/Sender/HttpSenderInterface.php
+++ b/src/Protocol/Http/Sender/HttpSenderInterface.php
@@ -37,4 +37,22 @@ interface HttpSenderInterface
      *
      */
     public function addRequest(Request $request, callable $callback);
+
+    /**
+     * Set max concurrent requests.
+     *
+     * @param int $maxRequests
+     *
+     * @return HttpSenderInterface
+     */
+    public function maxRequests(int $maxRequests): HttpSenderInterface;
+
+    /**
+     * Set the global requests timeout.
+     *
+     * @param int $timeout
+     *
+     * @return HttpSenderInterface
+     */
+    public function timeout(int $timeout): HttpSenderInterface;
 }

--- a/src/Protocol/ProtocolInterface.php
+++ b/src/Protocol/ProtocolInterface.php
@@ -29,12 +29,9 @@ interface ProtocolInterface
      * @param Notification $notification
      * @param bool         $sandbox
      *
-     * @throws SendNotificationException
+     * @return void
      */
-    public function send(Receiver $receiver, Notification $notification, bool $sandbox): void;
+    public function prepare(Receiver $receiver, Notification $notification, bool $sandbox);
 
-    /**
-     * Close the connection
-     */
-    public function closeConnection(): void;
+    public function send(): void;
 }

--- a/src/Sender/Builder/BuilderInterface.php
+++ b/src/Sender/Builder/BuilderInterface.php
@@ -24,9 +24,12 @@ interface BuilderInterface
     /**
      * Build the protocol for send the notification to devices
      *
+     * @param int $maxRequests
+     * @param int $timeout
+     *
      * @return ProtocolInterface
      */
-    public function buildProtocol(): ProtocolInterface;
+    public function buildProtocol($maxRequests = 20, $timeout = 5000): ProtocolInterface;
 
     /**
      * Build sender for send notification to device via Apn Push service

--- a/src/Sender/Builder/Http20Builder.php
+++ b/src/Sender/Builder/Http20Builder.php
@@ -19,6 +19,7 @@ use Apple\ApnPush\Protocol\Http\Authenticator\AuthenticatorInterface;
 use Apple\ApnPush\Protocol\Http\ExceptionFactory\ExceptionFactory;
 use Apple\ApnPush\Protocol\Http\ExceptionFactory\ExceptionFactoryInterface;
 use Apple\ApnPush\Protocol\Http\Sender\CurlHttpSender;
+use Apple\ApnPush\Protocol\Http\Sender\CurlMultiSender;
 use Apple\ApnPush\Protocol\Http\Sender\HttpSenderInterface;
 use Apple\ApnPush\Protocol\Http\UriFactory\UriFactory;
 use Apple\ApnPush\Protocol\Http\UriFactory\UriFactoryInterface;
@@ -79,7 +80,7 @@ class Http20Builder implements BuilderInterface
         $this->visitors = new \SplPriorityQueue();
         $this->uriFactory = new UriFactory();
         $this->payloadEncoder = new PayloadEncoder();
-        $this->httpSender = new CurlHttpSender();
+        $this->httpSender = new CurlMultiSender();
         $this->exceptionFactory = new ExceptionFactory();
     }
 

--- a/src/Sender/Builder/Http20Builder.php
+++ b/src/Sender/Builder/Http20Builder.php
@@ -187,13 +187,13 @@ class Http20Builder implements BuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function buildProtocol(): ProtocolInterface
+    public function buildProtocol($maxRequests = 20, $timeout = 5000): ProtocolInterface
     {
         $chainVisitor = $this->createChainVisitor();
 
         return new HttpProtocol(
             $this->authenticator,
-            $this->httpSender,
+            $this->httpSender->timeout($timeout)->maxRequests($maxRequests),
             $this->payloadEncoder,
             $this->uriFactory,
             $chainVisitor,


### PR DESCRIPTION
Hello @ZhukV 

In response to #44 and #45.
I have found out that the function `curl_exec()` is the real performence decreaser. 

So i have created a new curl http class which has the ability to use concurrent requests. 

Meaning that you set a specific number of requests you want to have processed and the reset will be queued until the others have conpleted. 

I have tried to keep as much code that i could think of but i think that we should move away from using `exceptions` in the package completely and let it be up to the developer to parse the response because most of the time we will be looking at the status codes from apple anyway. 

So the new way allows you to loop through an array of tokens and send the same push notification to many devices using a `request queue`.



Consider this example:

```php
use Apple\ApnPush\Certificate\Certificate;
use Apple\ApnPush\Protocol\Http\Authenticator\CertificateAuthenticator;
use Apple\ApnPush\Sender\Builder\Http20Builder;
use Apple\ApnPush\Sender\Sender;

// Create certificate and authenticator
$certificate = new Certificate('/path/to/you/certificate.pem', 'pass phrase');
$authenticator = new CertificateAuthenticator($certificate);

// Build sender
$builder = new Http20Builder($authenticator);
$builder->addDefaultVisitors();

$protocol = $builder->buildProtocol(
    50 /** how many requests is the maximum allowed at once? */, 
    15000 /** how long until we should timeout the requests? */
);

$sender = new Sender($protocol); 

$notification = Payload::withBody('hello there');

foreach($deviceTokens as $deviceToken) {
    $sender->prepare(
        new Receiver(new DeviceToken('some-token'), 'my.topic');
        $notification
     );
}

$sender->send();
```

### Note: 
I haven't updated any tests yet. And i haven't had the time to test this propertly manually just yet. 