### PR TITLE
Ability to send a notification which sets 'badge' to 0

### DIFF
--- a/src/Encoder/PayloadEncoder.php
+++ b/src/Encoder/PayloadEncoder.php
@@ -53,7 +53,7 @@ class PayloadEncoder implements PayloadEncoderInterface
             $data['sound'] = $aps->getSound();
         }
 
-        if ($aps->getBadge()) {
+        if ($aps->getBadge() !== null) {
             $data['badge'] = $aps->getBadge();
         }
 

--- a/src/Model/Aps.php
+++ b/src/Model/Aps.php
@@ -24,9 +24,9 @@ class Aps
     private $alert;
 
     /**
-     * @var int
+     * @var int|null
      */
-    private $badge = 0;
+    private $badge = null;
 
     /**
      * @var string
@@ -160,9 +160,9 @@ class Aps
     /**
      * Get badge
      *
-     * @return int
+     * @return int|null
      */
-    public function getBadge(): int
+    public function getBadge(): ?int
     {
         return $this->badge;
     }


### PR DESCRIPTION
Sending badge=0 tells the target app to clear its badge.

This is not the same as excluding the badge key from the payload, which tells the target app to leave its current badge unchanged.