### PR TITLE
Feature/add jwt signature generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+## v3.0.6
+
+### Features
+
+* Add `JwtSignatureGenerator` for available use any libraries for generating the signature from JWT token.
+* Support next libraries:
+    * [spomky-labs/jose](https://github.com/Spomky-Labs/jose)
+    * [web-token/jwt-*](https://www.gitbook.com/book/web-token/jwt-framework)
+
+### Impact
+
+Make changes without impact, all code has a BC. If previously you use `SpomkyLabs`, the factory has been successfully 
+creating require the generator.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,56 +1,14 @@
-FROM debian:9.1
+FROM php:7.2-cli
 
 MAINTAINER Vitaliy Zhuk <v.zhukv@fivelab.org>
 
-ENV LC_ALL en_US.UTF-8
-ENV LANGUAGE en_US:en
-
-# Install common packages and fix locales
 RUN \
-    apt-get update && \
-    apt-get -y --no-install-recommends install locales apt-utils && \
-    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-    locale-gen en_US.UTF-8 && \
-    /usr/sbin/update-locale LANG=en_US.UTF-8
-
-# Install cURL with SSL and HTTP 2.0
-RUN \
-    apt-get -y --no-install-recommends install \
-        build-essential \
-        nghttp2 \
-        libnghttp2-dev \
-        libssl-dev \
-        ca-certificates \
-        zip \
-        unzip \
-        wget \
-        apt-transport-https \
-        lsb-release && \
-
-    mkdir -p /tmp/install-curl && \
-    cd /tmp/install-curl && \
-    wget https://curl.haxx.se/download/curl-7.54.0.tar.bz2 && \
-    tar -xvjf curl-7.54.0.tar.bz2 && \
-    cd curl-7.54.0 && \
-    ./configure --with-nghttp2 --with-ssl --prefix=/usr/local && \
-    make && \
-    make install && \
-    ldconfig
-
-RUN \
-    wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
-    echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
-    apt-get update
-
-# Install PHP and depends packages
-RUN \
-    apt-get -y --no-install-recommends install \
-        php7.1 \
-        php7.1-xml \
-        php7.1-mbstring \
-        php7.1-curl \
-        php7.1-gmp \
-        php7.1-xdebug
+	apt-get update && \
+	apt-get install -y --no-install-recommends \
+		libgmp-dev \
+		zip unzip \
+		git && \
+	docker-php-ext-install gmp
 
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,15 @@
 
     "require-dev": {
         "phpunit/phpunit": "^5.6.0",
-        "spomky-labs/jose": "^6.1.0",
+        "web-token/jwt-key-mgmt": "~1.0",
+        "web-token/jwt-signature": "~1.0",
         "phpmetrics/phpmetrics": "^2.0",
         "escapestudios/symfony2-coding-standard": "~3.0.0"
     },
 
     "suggest": {
-        "spomky-labs/jose": "Allow using JSON Web Token for authenticating in Provider."
+        "web-token/jwt-key-mgmt": "Allow using JSON Web Token for authenticating in Provider.",
+        "web-token/jwt-signature": "Allow using JSON Web Token for authenticating in Provider."
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
 
     "suggest": {
         "web-token/jwt-key-mgmt": "Allow using JSON Web Token for authenticating in Provider.",
-        "web-token/jwt-signature": "Allow using JSON Web Token for authenticating in Provider."
+        "web-token/jwt-signature": "Allow using JSON Web Token for authenticating in Provider.",
+        "spomky-labs/jose": "Allow using JSON Web Token for authenticating in Provider (do not work with PHP 7.2). "
     },
 
     "autoload": {

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ $sender = $builder->build();
 
 We support the JSON Web Token authentication, and if you want use JWT, please create `JwtAuthenticator`:
 
-> **Attention:** For use JWT, the package **spomky-labs/jose** must be installed.
+> **Attention:** For use JWT, please install required packages for success generate signature from JSON Web Token.
 
 ```php
 <?php

--- a/src/Jwt/SignatureGenerator/SignatureGeneratorFactory.php
+++ b/src/Jwt/SignatureGenerator/SignatureGeneratorFactory.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the AppleApnPush package
+ *
+ * (c) Vitaliy Zhuk <zhuk2205@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace Apple\ApnPush\Jwt\SignatureGenerator;
+
+use Jose\Component\Core\JWK;
+use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\Signature\JWS;
+
+/**
+ * The factory for try to resolve the JWT signature generator.
+ */
+class SignatureGeneratorFactory
+{
+    /**
+     * @var array|callable[]
+     */
+    private static $resolvers = [];
+
+    /**
+     * Add resolver for try to resolve the signature generator
+     *
+     * @param callable $resolver
+     */
+    public static function addResolver(callable $resolver): void
+    {
+        array_unshift(self::$resolvers, $resolver);
+    }
+
+    /**
+     * Try to resolve the signature generator
+     *
+     * @return SignatureGeneratorInterface
+     *
+     * @throws \LogicException
+     */
+    public static function resolve(): SignatureGeneratorInterface
+    {
+        self::addDefaultResolvers();
+
+        foreach (self::$resolvers as $resolver) {
+            if ($generator = $resolver()) {
+                return $generator;
+            }
+        }
+
+        throw new \LogicException('Cannot resolve available JWT Signature Generator.');
+    }
+
+    /**
+     * Add default signature generator resolvers
+     */
+    private static function addDefaultResolvers(): void
+    {
+        static $added = false;
+
+        if ($added) {
+            return;
+        }
+
+        self::addResolver([__CLASS__, 'tryResolveByWebTokenJwtSystem']);
+    }
+
+    /**
+     * Try the resolve WebTokenJwtSignatureGenerator
+     *
+     * @return WebTokenJwtSignatureGenerator|null
+     */
+    private static function tryResolveByWebTokenJwtSystem(): ?WebTokenJwtSignatureGenerator
+    {
+        $requiredClasses = [
+            JWS::class,
+            JWK::class,
+            JWKFactory::class,
+        ];
+
+        foreach ($requiredClasses as $requiredClass) {
+            if (!class_exists($requiredClass)) {
+                return null;
+            }
+        }
+
+        return new WebTokenJwtSignatureGenerator();
+    }
+}

--- a/src/Jwt/SignatureGenerator/SignatureGeneratorFactory.php
+++ b/src/Jwt/SignatureGenerator/SignatureGeneratorFactory.php
@@ -70,6 +70,8 @@ class SignatureGeneratorFactory
             return;
         }
 
+        $added = true;
+
         self::addResolver([__CLASS__, 'tryResolveByWebTokenJwtSystem']);
         self::addResolver([__CLASS__, 'tryResolveBySpomkyLabsJoseSystem']);
     }

--- a/src/Jwt/SignatureGenerator/SignatureGeneratorFactory.php
+++ b/src/Jwt/SignatureGenerator/SignatureGeneratorFactory.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Apple\ApnPush\Jwt\SignatureGenerator;
 
-use Jose\Component\Core\JWK;
-use Jose\Component\KeyManagement\JWKFactory;
-use Jose\Component\Signature\JWS;
+use Jose\Component\Core\JWK as WebTokenComponentJwk;
+use Jose\Component\KeyManagement\JWKFactory as WebTokenComponentJWKFactory;
+use Jose\Component\Signature\JWS as WebTokenComponentJws;
+use Jose\Factory\JWKFactory;
+use Jose\Factory\JWSFactory;
 
 /**
  * The factory for try to resolve the JWT signature generator.
@@ -69,6 +71,7 @@ class SignatureGeneratorFactory
         }
 
         self::addResolver([__CLASS__, 'tryResolveByWebTokenJwtSystem']);
+        self::addResolver([__CLASS__, 'tryResolveBySpomkyLabsJoseSystem']);
     }
 
     /**
@@ -79,9 +82,9 @@ class SignatureGeneratorFactory
     private static function tryResolveByWebTokenJwtSystem(): ?WebTokenJwtSignatureGenerator
     {
         $requiredClasses = [
-            JWS::class,
-            JWK::class,
-            JWKFactory::class,
+            WebTokenComponentJws::class,
+            WebTokenComponentJwk::class,
+            WebTokenComponentJWKFactory::class,
         ];
 
         foreach ($requiredClasses as $requiredClass) {
@@ -91,5 +94,26 @@ class SignatureGeneratorFactory
         }
 
         return new WebTokenJwtSignatureGenerator();
+    }
+
+    /**
+     * Try to resolve SpomkyLabsJoseSignatureGenerator
+     *
+     * @return SpomkyLabsJoseSignatureGenerator|null
+     */
+    private static function tryResolveBySpomkyLabsJoseSystem(): ?SpomkyLabsJoseSignatureGenerator
+    {
+        $requiredClasses = [
+            JWKFactory::class,
+            JWSFactory::class,
+        ];
+
+        foreach ($requiredClasses as $requiredClass) {
+            if (!class_exists($requiredClass)) {
+                return null;
+            }
+        }
+
+        return new SpomkyLabsJoseSignatureGenerator();
     }
 }

--- a/src/Jwt/SignatureGenerator/SignatureGeneratorInterface.php
+++ b/src/Jwt/SignatureGenerator/SignatureGeneratorInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types = 1);
+
+/*
+ * This file is part of the AppleApnPush package
+ *
+ * (c) Vitaliy Zhuk <zhuk2205@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace Apple\ApnPush\Jwt\SignatureGenerator;
+
+use Apple\ApnPush\Jwt\JwtInterface;
+
+/**
+ * All JWT signature generators should implement this interface.
+ */
+interface SignatureGeneratorInterface
+{
+    /**
+     * Generate the signature for JSON Web Token
+     *
+     * @param JwtInterface $jwt
+     *
+     * @return string
+     */
+    public function generate(JwtInterface $jwt): string;
+}

--- a/src/Jwt/SignatureGenerator/SpomkyLabsJoseSignatureGenerator.php
+++ b/src/Jwt/SignatureGenerator/SpomkyLabsJoseSignatureGenerator.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types = 1);
+
+/*
+ * This file is part of the AppleApnPush package
+ *
+ * (c) Vitaliy Zhuk <zhuk2205@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace Apple\ApnPush\Jwt\SignatureGenerator;
+
+use Apple\ApnPush\Jwt\JwtInterface;
+use Jose\Factory\JWKFactory;
+use Jose\Factory\JWSFactory;
+
+/**
+ * The signature generator with use "spomky-labs/jose" library.
+ */
+class SpomkyLabsJoseSignatureGenerator implements SignatureGeneratorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(JwtInterface $jwt): string
+    {
+        $jwk = JWKFactory::createFromKeyFile($jwt->getPath(), '', [
+            'kid' => $jwt->getKey(),
+            'alg' => 'ES256',
+            'use' => 'sig',
+        ]);
+
+        $payload = [
+            'iss' => $jwt->getTeamId(),
+            'iat' => time(),
+        ];
+
+        $header = [
+            'alg' => 'ES256',
+            'kid' => $jwk->get('kid'),
+        ];
+
+        return JWSFactory::createJWSToCompactJSON(
+            $payload,
+            $jwk,
+            $header
+        );
+    }
+}

--- a/src/Jwt/SignatureGenerator/WebTokenJwtSignatureGenerator.php
+++ b/src/Jwt/SignatureGenerator/WebTokenJwtSignatureGenerator.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types = 1);
+
+/*
+ * This file is part of the AppleApnPush package
+ *
+ * (c) Vitaliy Zhuk <zhuk2205@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace Apple\ApnPush\Jwt\SignatureGenerator;
+
+use Apple\ApnPush\Jwt\JwtInterface;
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\Converter\JsonConverter;
+use Jose\Component\Core\Converter\StandardConverter;
+use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\Signature\Algorithm\ES256;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Component\Signature\Serializer\JWSSerializer;
+
+/**
+ * The JWT signature generator worked with "web-token/jwt-*" libraries.
+ *
+ * Next libraries must be installed:
+ *      - web-token/jwt-key-mgmt
+ *      - web-token/jwt-core
+ *      - web-token/jwt-signature
+ */
+class WebTokenJwtSignatureGenerator implements SignatureGeneratorInterface
+{
+    /**
+     * @var JsonConverter
+     */
+    private $jsonConverter;
+
+    /**
+     * @var JWSBuilder
+     */
+    private $jwsBuilder;
+
+    /**
+     * @var JWSSerializer
+     */
+    private $serializer;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->jsonConverter = new StandardConverter();
+        $this->jwsBuilder = new JWSBuilder($this->jsonConverter, AlgorithmManager::create([new ES256()]));
+        $this->serializer = new CompactSerializer($this->jsonConverter);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(JwtInterface $jwt): string
+    {
+        $jwk = JWKFactory::createFromKeyFile($jwt->getPath(), '', [
+            'kid' => $jwt->getKey()
+        ]);
+
+        $claims = [
+            'iss' => $jwt->getTeamId(),
+            'iat' => time(),
+        ];
+
+        $header = [
+            'alg' => 'ES256',
+            'kid' => $jwk->get('kid'),
+        ];
+
+        $payload = $this->jsonConverter->encode($claims);
+
+        $jws = $this->jwsBuilder
+            ->create()
+            ->withPayload($payload)
+            ->addSignature($jwk, $header)
+            ->build();
+
+        return $this->serializer->serialize($jws);
+    }
+}

--- a/src/Jwt/SignatureGenerator/WebTokenJwtSignatureGenerator.php
+++ b/src/Jwt/SignatureGenerator/WebTokenJwtSignatureGenerator.php
@@ -64,7 +64,7 @@ class WebTokenJwtSignatureGenerator implements SignatureGeneratorInterface
     public function generate(JwtInterface $jwt): string
     {
         $jwk = JWKFactory::createFromKeyFile($jwt->getPath(), '', [
-            'kid' => $jwt->getKey()
+            'kid' => $jwt->getKey(),
         ]);
 
         $claims = [

--- a/tests/Protocol/Http/Authenticator/JwtAuthenticatorTest.php
+++ b/tests/Protocol/Http/Authenticator/JwtAuthenticatorTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the AppleApnPush package
+ *
+ * (c) Vitaliy Zhuk <zhuk2205@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ */
+
+namespace Tests\Apple\ApnPush\Protocol\Http\Authenticator;
+
+use Apple\ApnPush\Jwt\JwtInterface;
+use Apple\ApnPush\Jwt\SignatureGenerator\SignatureGeneratorInterface;
+use Apple\ApnPush\Protocol\Http\Authenticator\JwtAuthenticator;
+use Apple\ApnPush\Protocol\Http\Request;
+use PHPUnit\Framework\TestCase;
+
+class JwtAuthenticatorTest extends TestCase
+{
+    /**
+     * @var SignatureGeneratorInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $signatureGenerator;
+
+    /**
+     * @var JwtInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $jwt;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->signatureGenerator = $this->createMock(SignatureGeneratorInterface::class);
+        $this->jwt = $this->createMock(JwtInterface::class);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSuccessAuthenticate(): void
+    {
+        $this->signatureGenerator->expects(self::once())
+            ->method('generate')
+            ->with($this->jwt)
+            ->willReturn('some-authenticated-token');
+
+        $authenticator = new JwtAuthenticator($this->jwt, null, $this->signatureGenerator);
+        $request = new Request('https://some-foo-bar.com', 'some');
+
+        $resultRequest = $authenticator->authenticate($request);
+
+        self::assertNotEquals(spl_object_hash($request), spl_object_hash($resultRequest));
+
+        self::assertEquals([
+            'authorization' => 'bearer some-authenticated-token',
+        ], $resultRequest->getHeaders());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldDoNotGenerateNewTokenWithLifetime(): void
+    {
+        $this->signatureGenerator->expects(self::once())
+            ->method('generate')
+            ->with($this->jwt)
+            ->willReturn('some-authenticated-token');
+
+        $authenticator = new JwtAuthenticator($this->jwt, new \DateInterval('PT1M'), $this->signatureGenerator);
+        $request = new Request('https://some-foo-bar.com', 'some');
+
+        $resultRequest1 = $authenticator->authenticate($request);
+        $resultRequest2 = $authenticator->authenticate($resultRequest1);
+        $resultRequest3 = $authenticator->authenticate($resultRequest2);
+
+        self::assertNotEquals(spl_object_hash($request), spl_object_hash($resultRequest3));
+
+        self::assertEquals([
+            'authorization' => 'bearer some-authenticated-token',
+        ], $resultRequest3->getHeaders());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRegenerateWithoutLifetime(): void
+    {
+        $this->signatureGenerator->expects(self::exactly(3))
+            ->method('generate')
+            ->with($this->jwt)
+            ->willReturn(
+                'some-authenticated-token-1',
+                'some-authenticated-token-2',
+                'some-authenticated-token-3'
+            );
+
+        $authenticator = new JwtAuthenticator($this->jwt, null, $this->signatureGenerator);
+        $request = new Request('https://some-foo-bar.com', 'some');
+
+        $resultRequest1 = $authenticator->authenticate($request);
+        $resultRequest2 = $authenticator->authenticate($resultRequest1);
+        $resultRequest3 = $authenticator->authenticate($resultRequest2);
+
+        self::assertNotEquals(spl_object_hash($request), spl_object_hash($resultRequest3));
+
+        self::assertEquals([
+            'authorization' => 'bearer some-authenticated-token-3',
+        ], $resultRequest3->getHeaders());
+    }
+}


### PR DESCRIPTION
We have a problem with run on `PHP 7.2` but the SpomkyLabs dependencies do not support `PHP 7.2` (with rule `< PHP 7.1`).

In this solution, we make the factory for dynamically create the signature generator and use this generator in authenticator. All BC is saved and should correct work after merging the PR.