### PR TITLE
Make $alert optional

### DIFF
--- a/src/Encoder/PayloadEncoder.php
+++ b/src/Encoder/PayloadEncoder.php
@@ -45,9 +45,11 @@ class PayloadEncoder implements PayloadEncoderInterface
      */
     private function convertApsToArray(Aps $aps): array
     {
-        $data = [
-            'alert' => $this->convertAlertToArray($aps->getAlert()),
-        ];
+        $data = [];
+
+        if ($aps->getAlert()) {
+            $data['alert'] = $this->convertAlertToArray($aps->getAlert());
+        }
 
         if ($aps->getSound()) {
             $data['sound'] = $aps->getSound();

--- a/src/Model/Aps.php
+++ b/src/Model/Aps.php
@@ -84,7 +84,7 @@ class Aps
      *
      * @return Alert
      */
-    public function getAlert(): Alert
+    public function getAlert(): ?Alert
     {
         return $this->alert;
     }

--- a/src/Model/Aps.php
+++ b/src/Model/Aps.php
@@ -58,7 +58,7 @@ class Aps
      *
      * @param Alert $alert
      */
-    public function __construct(Alert $alert)
+    public function __construct(?Alert $alert)
     {
         $this->alert = $alert;
     }

--- a/src/Model/Aps.php
+++ b/src/Model/Aps.php
@@ -58,7 +58,7 @@ class Aps
      *
      * @param Alert $alert
      */
-    public function __construct(?Alert $alert)
+    public function __construct(?Alert $alert = null)
     {
         $this->alert = $alert;
     }

--- a/tests/Encoder/PayloadEncoderTest.php
+++ b/tests/Encoder/PayloadEncoderTest.php
@@ -178,13 +178,13 @@ class PayloadEncoderTest extends TestCase
      */
     public function shouldSuccessEncodeWithContentAvailable()
     {
-        $aps = new Aps(new Alert());
+        $aps = new Aps();
         $aps = $aps->withContentAvailable(true);
 
         $payload = new Payload($aps);
         $encoded = $this->encoder->encode($payload);
 
-        self::assertEquals('{"aps":{"alert":{"body":""},"content-available":1}}', $encoded);
+        self::assertEquals('{"aps":{"content-available":1}}', $encoded);
     }
 
     /**


### PR DESCRIPTION
Silent background notifications are not supposed to include the ‘alert’
key. Fixes #59.