### PR TITLE
Allow localized and non-localized text to exist in same payload

### DIFF
--- a/src/Encoder/PayloadEncoder.php
+++ b/src/Encoder/PayloadEncoder.php
@@ -92,14 +92,18 @@ class PayloadEncoder implements PayloadEncoderInterface
         if ($alert->getBodyLocalized()->getKey()) {
             $data['loc-key'] = $alert->getBodyLocalized()->getKey();
             $data['loc-args'] = $alert->getBodyLocalized()->getArgs();
-        } else {
+        }
+        
+        if ($alert->getBody()) {
             $data['body'] = $alert->getBody();
         }
 
         if ($alert->getTitleLocalized()->getKey()) {
             $data['title-loc-key'] = $alert->getTitleLocalized()->getKey();
             $data['title-loc-args'] = $alert->getTitleLocalized()->getArgs();
-        } elseif ($alert->getTitle()) {
+        }
+        
+        if ($alert->getTitle()) {
             $data['title'] = $alert->getTitle();
         }
 

--- a/src/Model/Alert.php
+++ b/src/Model/Alert.php
@@ -74,7 +74,6 @@ class Alert
     {
         $cloned = clone $this;
 
-        $cloned->titleLocalized = new Localized('');
         $cloned->title = $title;
 
         return $cloned;
@@ -91,7 +90,6 @@ class Alert
     {
         $cloned = clone $this;
 
-        $cloned->title = '';
         $cloned->titleLocalized = $localized;
 
         return $cloned;
@@ -128,7 +126,6 @@ class Alert
     {
         $cloned = clone $this;
 
-        $cloned->bodyLocalized = new Localized('');
         $cloned->body = $body;
 
         return $cloned;
@@ -145,7 +142,6 @@ class Alert
     {
         $cloned = clone $this;
 
-        $cloned->body = '';
         $cloned->bodyLocalized = $localized;
 
         return $cloned;

--- a/src/Model/Aps.php
+++ b/src/Model/Aps.php
@@ -84,7 +84,7 @@ class Aps
      *
      * @return Alert
      */
-    public function getAlert(): Alert
+    public function getAlert(): ?Alert
     {
         return $this->alert;
     }


### PR DESCRIPTION
The `body` and `loc-*` keys are not mutually exclusive. Same with `title` and `title-loc-*` keys. For example, you may want to send a push notification with non-localized text for older clients that do not have the `loc-*` keys in their bundle. This change allows localized and non-localized keys to coexist in same payload.