### PR TITLE
fixes for breaking changes in JWT framework 2/3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "phpunit/phpunit": "^8.0 | ^9.0",
         "web-token/jwt-key-mgmt": "~2.0",
         "web-token/jwt-signature": "~2.0",
+        "web-token/jwt-signature-algorithm-ecdsa": "~2.0",
         "phpmetrics/phpmetrics": "^2.0",
         "escapestudios/symfony2-coding-standard": "~3.0",
         "psr/simple-cache":  "~1.0"
@@ -30,6 +31,7 @@
     "suggest": {
         "web-token/jwt-key-mgmt": "Allow using JSON Web Token for authenticating in Provider.",
         "web-token/jwt-signature": "Allow using JSON Web Token for authenticating in Provider.",
+        "web-token/jwt-signature-algorithm-ecdsa": "Allow using JSON Web Token for authenticating in Provider.",
         "spomky-labs/jose": "Allow using JSON Web Token for authenticating in Provider (do not work with PHP 7.2)."
     },
 

--- a/src/Jwt/SignatureGenerator/WebTokenJwtSignatureGenerator.php
+++ b/src/Jwt/SignatureGenerator/WebTokenJwtSignatureGenerator.php
@@ -15,10 +15,9 @@ namespace Apple\ApnPush\Jwt\SignatureGenerator;
 
 use Apple\ApnPush\Jwt\JwtInterface;
 use Jose\Component\Core\AlgorithmManager;
-use Jose\Component\Core\Converter\JsonConverter;
-use Jose\Component\Core\Converter\StandardConverter;
-use Jose\Component\KeyManagement\JWKFactory;
+use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\Signature\Algorithm\ES256;
+use Jose\Component\KeyManagement\JWKFactory;
 use Jose\Component\Signature\JWSBuilder;
 use Jose\Component\Signature\Serializer\CompactSerializer;
 use Jose\Component\Signature\Serializer\JWSSerializer;
@@ -29,15 +28,10 @@ use Jose\Component\Signature\Serializer\JWSSerializer;
  * Next libraries must be installed:
  *      - web-token/jwt-key-mgmt
  *      - web-token/jwt-core
- *      - web-token/jwt-signature
+ *      - web-token/jwt-signature-algorithm-ecdsa
  */
 class WebTokenJwtSignatureGenerator implements SignatureGeneratorInterface
 {
-    /**
-     * @var JsonConverter
-     */
-    private $jsonConverter;
-
     /**
      * @var JWSBuilder
      */
@@ -53,9 +47,9 @@ class WebTokenJwtSignatureGenerator implements SignatureGeneratorInterface
      */
     public function __construct()
     {
-        $this->jsonConverter = new StandardConverter();
-        $this->jwsBuilder = new JWSBuilder($this->jsonConverter, AlgorithmManager::create([new ES256()]));
-        $this->serializer = new CompactSerializer($this->jsonConverter);
+        $algorithmManager = new AlgorithmManager([new ES256()]);
+        $this->jwsBuilder = new JWSBuilder($algorithmManager);
+        $this->serializer = new CompactSerializer();
     }
 
     /**
@@ -77,7 +71,7 @@ class WebTokenJwtSignatureGenerator implements SignatureGeneratorInterface
             'kid' => $jwk->get('kid'),
         ];
 
-        $payload = $this->jsonConverter->encode($claims);
+        $payload = JsonConverter::encode($claims);
 
         $jws = $this->jwsBuilder
             ->create()


### PR DESCRIPTION
The code in WebTokenJwtSignatureGenerator no longer works with the latest versions of JWT framework. This PR fixes it. 

See https://web-token.spomky-labs.com/v/v2.x/migration-1/migration/from-v1.x-to-v2.0