### PR TITLE
Support the `liveactivity` push type

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,6 @@ name: Testing
 on:
     push:
     pull_request:
-    workflow_dispatch:
 
 jobs:
     code-style:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,7 @@ name: Testing
 on:
     push:
     pull_request:
+    workflow_dispatch:
 
 jobs:
     code-style:

--- a/src/Model/PushType.php
+++ b/src/Model/PushType.php
@@ -21,6 +21,7 @@ final class PushType
 {
     const TYPE_ALERT      = 'alert';
     const TYPE_BACKGROUND = 'background';
+    const TYPE_LIVEACTIVITY = 'liveactivity';
 
     private $value;
 
@@ -45,6 +46,16 @@ final class PushType
     }
 
     /**
+     * Create liveactivity push-type
+     *
+     * @return PushType
+     */
+    public static function liveactivity(): PushType
+    {
+        return new self(self::TYPE_LIVEACTIVITY);
+    }
+
+    /**
      * @return string
      */
     public function __toString(): string
@@ -59,12 +70,13 @@ final class PushType
      */
     private function __construct(string $type)
     {
-        if (!\in_array($type, [self::TYPE_ALERT, self::TYPE_BACKGROUND], true)) {
+        if (!\in_array($type, [self::TYPE_ALERT, self::TYPE_BACKGROUND, self::TYPE_LIVEACTIVITY], true)) {
             throw new \InvalidArgumentException(\sprintf(
-                'Invalid priority "%d". Can be "%s" or "%s".',
+                'Invalid priority "%d". Can be "%s", "%s", or "%s".',
                 $type,
                 self::TYPE_BACKGROUND,
-                self::TYPE_ALERT
+                self::TYPE_ALERT,
+                self::TYPE_LIVEACTIVITY
             ));
         }
 

--- a/tests/Model/PushTypeTest.php
+++ b/tests/Model/PushTypeTest.php
@@ -23,5 +23,6 @@ class PushTypeTest extends TestCase
     {
         self::assertEquals(PushType::TYPE_ALERT, (string) PushType::alert());
         self::assertEquals(PushType::TYPE_BACKGROUND, (string) PushType::background());
+        self::assertEquals(PushType::TYPE_LIVEACTIVITY, (string) PushType::liveactivity());
     }
 }


### PR DESCRIPTION
This PR adds support for passing `liveactivity` as the value for the APNs `push-type` header to support sending updates for iOS Live Activities[^1].

From the Apple API docs
> Set the value for the `apns-push-type` header field of the request you sent to APNs to `liveactivity`.[^2]

[^1]: [Displaying live data with Live Activities](https://developer.apple.com/documentation/activitykit/displaying-live-data-with-live-activities)
[^2]: [Update your app’s code and create a push notification server](https://developer.apple.com/documentation/activitykit/updating-and-ending-your-live-activity-with-activitykit-push-notifications#Update-your-apps-code-and-create-a-push-notification-server)