### PR TITLE
Support custom data in the `aps` payload property

### DIFF
--- a/src/Encoder/PayloadEncoder.php
+++ b/src/Encoder/PayloadEncoder.php
@@ -91,7 +91,7 @@ class PayloadEncoder implements PayloadEncoderInterface
             $data['url-args'] = $aps->getUrlArgs();
         }
 
-        return $data;
+        return array_merge($data, $aps->getCustomData());
     }
 
     /**

--- a/src/Model/Aps.php
+++ b/src/Model/Aps.php
@@ -59,13 +59,20 @@ class Aps
     private $urlArgs = null;
 
     /**
+     * @var array
+     */
+    private $customData;
+
+    /**
      * Constructor.
      *
      * @param Alert|null $alert
+     * @param array      $customData
      */
-    public function __construct(Alert $alert = null)
+    public function __construct(Alert $alert = null, array $customData = [])
     {
-        $this->alert = $alert;
+        $this->alert      = $alert;
+        $this->customData = $customData;
     }
 
     /**
@@ -282,5 +289,41 @@ class Aps
     public function getUrlArgs(): ?array
     {
         return $this->urlArgs;
+    }
+
+    /**
+     * Get custom data
+     *
+     * @return array
+     */
+    public function getCustomData(): array
+    {
+        return $this->customData;
+    }
+
+    /**
+     * Add or replace custom data
+     *
+     * @param string $name
+     * @param mixed  $value
+     *
+     * @return Aps
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function withCustomData(string $name, $value): Aps
+    {
+        if ($value && !is_array($value) && !is_scalar($value) && !$value instanceof \JsonSerializable) {
+            throw new \InvalidArgumentException(sprintf(
+                'The custom data value should be a scalar or \JsonSerializable instance, but "%s" given.',
+                is_object($value) ? get_class($value) : gettype($value)
+            ));
+        }
+
+        $cloned = clone $this;
+
+        $cloned->customData[$name] = $value;
+
+        return $cloned;
     }
 }

--- a/tests/Encoder/PayloadEncoderTest.php
+++ b/tests/Encoder/PayloadEncoderTest.php
@@ -304,4 +304,18 @@ class PayloadEncoderTest extends TestCase
 
         self::assertEquals('{"some":"key","foo":["bar"],"aps":{"alert":{"body":""}}}', $encoded);
     }
+
+    /**
+     * @test
+     */
+    public function shouldSuccessEncodeWithCustomApsData(): void
+    {
+        $aps     = new Aps(new Alert(), ['foo' => ['bar']]);
+        $aps     = $aps->withCustomData('some', 'key');
+        $payload = new Payload($aps);
+
+        $encoded = $this->encoder->encode($payload);
+
+        self::assertEquals('{"aps":{"alert":{"body":""},"foo":["bar"],"some":"key"}}', $encoded);
+    }
 }


### PR DESCRIPTION
This PR allows for setting custom data in the `aps` property of the APNs payload, as required by Apple for sending live activity push notifications. For example, from the Apple docs[^1]:
```json
{
    "aps": {
        "timestamp": 1168364460,
        "event": "update",
        "relevance-score": 75.0,
        "stale-date": 1650998941,
        "content-state": {
            "driverName": "Anne Johnson",
            "estimatedDeliveryTime": 1659416400
        },
        "alert": {
            "title": "Delivery Update",
            "body": "Your pizza order will arrive soon.",
            "sound": "example.aiff" 
        }
    }
}
```

Example usage:
```php
$aps     = new Aps(new Alert(), ['foo' => ['bar']]);
$aps     = $aps->withCustomData('some', 'key');
$payload = new Payload($aps);

$encoded = $this->encoder->encode($payload);
```        

Resulting JSON object:
```json
{
  "aps": {
    "alert": {
      "body": ""
    },
    "foo": [
      "bar"
    ],
    "some": "key"
  }
}
```

Adding a `customData` property to the `Aps` object seemed to follow the precedent set by the `Payload` object, as opposed to updating the `PayloadEncoder` to overwrite the `aps` property from `Payload::getCustomData()`. 

[^1]: [Update your app’s code and create a push notification server](https://developer.apple.com/documentation/activitykit/updating-and-ending-your-live-activity-with-activitykit-push-notifications#Update-your-apps-code-and-create-a-push-notification-server)