### PR TITLE
Remove strict requirement of device token length

### DIFF
--- a/src/Model/DeviceToken.php
+++ b/src/Model/DeviceToken.php
@@ -32,7 +32,7 @@ class DeviceToken
      */
     public function __construct(string $token)
     {
-        if (!\preg_match('/^[0-9a-fA-F]{64}$/', $token)) {
+        if (!\preg_match('/^[0-9a-fA-F]+$/', $token)) {
             throw new \InvalidArgumentException(sprintf(
                 'Invalid device token "%s".',
                 $token

--- a/tests/Model/DeviceTokenTest.php
+++ b/tests/Model/DeviceTokenTest.php
@@ -22,9 +22,9 @@ class DeviceTokenTest extends TestCase
     public function shouldThrowsExceptionIfTokenIsInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid device token "some".');
+        $this->expectExceptionMessage('Invalid device token "invalid token with a space".');
 
-        new DeviceToken('some');
+        new DeviceToken('invalid token with a space');
     }
 
     /**


### PR DESCRIPTION
According to [this article](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622958-application), the device token no longer has a fixed size. And today I found such a token (160 characters in length) in our production environment.