### PR TITLE
Fix: Add explicit nullable typehints to resolve PHP deprecation warnings

### DIFF
--- a/src/Jwt/SignatureGenerator/CacheJwtSignatureGenerator.php
+++ b/src/Jwt/SignatureGenerator/CacheJwtSignatureGenerator.php
@@ -49,9 +49,9 @@ class CacheJwtSignatureGenerator implements SignatureGeneratorInterface
      * @param SignatureGeneratorInterface        $generator
      * @param CacheInterface                     $cache
      * @param JwtCacheKeyGeneratorInterface|null $cacheKeyGenerator
-     * @param \DateInterval                      $ttl
+     * @param \DateInterval|null                 $ttl
      */
-    public function __construct(SignatureGeneratorInterface $generator, CacheInterface $cache, JwtCacheKeyGeneratorInterface $cacheKeyGenerator = null, $ttl = null)
+    public function __construct(SignatureGeneratorInterface $generator, CacheInterface $cache, ?JwtCacheKeyGeneratorInterface $cacheKeyGenerator = null, ?\DateInterval $ttl = null)
     {
         $this->generator = $generator;
         $this->cache = $cache;

--- a/src/Model/Aps.php
+++ b/src/Model/Aps.php
@@ -69,7 +69,7 @@ class Aps
      * @param Alert|null $alert
      * @param array      $customData
      */
-    public function __construct(Alert $alert = null, array $customData = [])
+    public function __construct(?Alert $alert = null, array $customData = [])
     {
         $this->alert = $alert;
         $this->customData = $customData;

--- a/src/Model/Expiration.php
+++ b/src/Model/Expiration.php
@@ -26,9 +26,9 @@ class Expiration
     /**
      * Constructor.
      *
-     * @param \DateTime $availableTo
+     * @param \DateTime|null $availableTo
      */
-    public function __construct(\DateTime $availableTo = null)
+    public function __construct(?\DateTime $availableTo = null)
     {
         if ($availableTo) {
             $this->storeTo = clone $availableTo;

--- a/src/Model/Notification.php
+++ b/src/Model/Notification.php
@@ -58,7 +58,7 @@ class Notification
      * @param CollapseId|null $collapseId
      * @param PushType|null   $pushType
      */
-    public function __construct(Payload $payload, ApnId $apnId = null, Priority $priority = null, Expiration $expiration = null, CollapseId $collapseId = null, PushType $pushType = null)
+    public function __construct(Payload $payload, ?ApnId $apnId = null, ?Priority $priority = null, ?Expiration $expiration = null, ?CollapseId $collapseId = null, ?PushType $pushType = null)
     {
         $this->payload = $payload;
         $this->priority = $priority;
@@ -109,11 +109,11 @@ class Notification
     /**
      * Set apn identifier
      *
-     * @param ApnId $apnId
+     * @param ApnId|null $apnId
      *
      * @return Notification
      */
-    public function withApnId(ApnId $apnId = null): Notification
+    public function withApnId(?ApnId $apnId = null): Notification
     {
         $cloned = clone $this;
 
@@ -135,11 +135,11 @@ class Notification
     /**
      * Set priority
      *
-     * @param Priority $priority
+     * @param Priority|null $priority
      *
      * @return Notification
      */
-    public function withPriority(Priority $priority = null): Notification
+    public function withPriority(?Priority $priority = null): Notification
     {
         $cloned = clone $this;
 
@@ -161,11 +161,11 @@ class Notification
     /**
      * Set expiration
      *
-     * @param Expiration $expiration
+     * @param Expiration|null $expiration
      *
      * @return Notification
      */
-    public function withExpiration(Expiration $expiration = null): Notification
+    public function withExpiration(?Expiration $expiration = null): Notification
     {
         $cloned = clone $this;
 
@@ -191,7 +191,7 @@ class Notification
      *
      * @return Notification
      */
-    public function withCollapseId(CollapseId $collapseId = null): Notification
+    public function withCollapseId(?CollapseId $collapseId = null): Notification
     {
         $cloned = clone $this;
 

--- a/src/Protocol/Http/Authenticator/JwtAuthenticator.php
+++ b/src/Protocol/Http/Authenticator/JwtAuthenticator.php
@@ -58,7 +58,7 @@ class JwtAuthenticator implements AuthenticatorInterface
      * @throws \InvalidArgumentException
      * @throws \LogicException
      */
-    public function __construct(JwtInterface $jwt, \DateInterval $jwsLifetime = null, SignatureGeneratorInterface $signatureGenerator = null)
+    public function __construct(JwtInterface $jwt, ?\DateInterval $jwsLifetime = null, ?SignatureGeneratorInterface $signatureGenerator = null)
     {
         $this->jwt = $jwt;
 


### PR DESCRIPTION
**Description:**

This Pull Request addresses deprecation warnings related to implicitly marked nullable parameters when running the package with newer PHP versions (specifically PHP 8.1+ up to 8.4, where this deprecation is fully enforced).

**Problem:**
PHP 8.1 introduced a deprecation notice (`E_DEPRECATED`) for parameters that are implicitly marked as nullable (e.g., `function example($param = null)` without a `?` typehint). While still functional, this syntax will lead to errors in future PHP versions (e.g., PHP 9.0). This PR fixes warnings like:
`Implicitly marking parameter {paramName} as nullable is deprecated, the explicit nullable type must be used instead`

**Solution:**
The changes introduce explicit nullable typehints (`?Type`) for all parameters that can accept `null` as a value. This aligns the codebase with modern PHP best practices and eliminates the deprecation warnings.